### PR TITLE
star: Override vendor's usb_audio_policy_configuration

### DIFF
--- a/rootdir/etc/init.samsung.rc
+++ b/rootdir/etc/init.samsung.rc
@@ -2,6 +2,9 @@ on init
     # Disable vendor overlay
     mount none /vendor/lost+found /vendor/overlay bind
 
+    # Override vendor usb_audio_policy_configuration
+    mount none /system/etc/usb_audio_policy_configuration.xml /vendor/etc/usb_audio_policy_configuration.xml bind
+
     # MirrorLink permission
     mkdir /dev/socket/mlaudio 0770 audioserver system
 

--- a/sepolicy/private/file_contexts
+++ b/sepolicy/private/file_contexts
@@ -1,5 +1,6 @@
 # Audio
 /system/bin/audioloader u:object_r:audioloader_exec:s0
+/system/etc/usb_audio_policy_configuration.xml u:object_r:vendor_configs_file:s0
 
 # Bluetooth
 /sys/devices/platform/bluetooth/rfkill/rfkill0/state    u:object_r:sysfs_bluetooth_writable:s0

--- a/star-common.mk
+++ b/star-common.mk
@@ -81,6 +81,8 @@ USE_XML_AUDIO_POLICY_CONF := 1
 PRODUCT_PACKAGES += \
     libshim_audio \
     audioloader
+PRODUCT_COPY_FILES += \
+    frameworks/av/services/audiopolicy/config/usb_audio_policy_configuration.xml:system/etc/usb_audio_policy_configuration.xml
 
 # Bluetooth
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
Android 8.1 added the support for new type of USB Audio devices
(USB_HEADSET, instead of old USB_DEVICE)
Some older USB devices got converted to this USB_HEADSET while still
using the old protocol.
There is no driver change needed, but the audio policy needs to be
changed.
Since vendors are simply using AOSP usb_audio_policy_configuration
Override it by ourself.

Change-Id: I5c43cd7c95f721914cf94f4dc20c992b4f6a24e9
Signed-off-by: Jesse Chan <jc@lineageos.org>
Signed-off-by: msdx321 <msdx321@gmail.com>